### PR TITLE
RPM with Copy on Write: add deny list mechanism

### DIFF
--- a/build/pack.c
+++ b/build/pack.c
@@ -493,7 +493,7 @@ static rpmRC writeRPM(Package pkg, unsigned char ** pkgidp,
     }
 
     /* Write the lead section into the package. */
-    if (rpmLeadWrite(fd, pkg->header)) {
+    if (rpmLeadWriteFromHeader(fd, pkg->header)) {
 	rpmlog(RPMLOG_ERR, _("Unable to write package: %s\n"), Fstrerror(fd));
 	goto exit;
     }

--- a/lib/package.c
+++ b/lib/package.c
@@ -415,11 +415,7 @@ rpmRC rpmReadPackageRaw(FD_t fd, Header * sigp, Header * hdrp)
     Header h = NULL;
     Header sigh = NULL;
 
-    rpmRC rc = rpmLeadRead(fd, &msg);
-    if (rc != RPMRC_OK)
-	goto exit;
-
-    rc = hdrblobRead(fd, 1, 0, RPMTAG_HEADERSIGNATURES, sigblob, &msg);
+    rpmRC rc = hdrblobRead(fd, 1, 0, RPMTAG_HEADERSIGNATURES, sigblob, &msg);
     if (rc != RPMRC_OK)
 	goto exit;
 

--- a/lib/rpmlead.h
+++ b/lib/rpmlead.h
@@ -20,12 +20,38 @@ extern "C" {
 #define RPMLEAD_SIZE 96         /*!< Don't rely on sizeof(struct) */
 
 /** \ingroup lead
+ * The lead data structure.
+ * The lead needs to be 8 byte aligned.
+ * @deprecated The lead (except for signature_type) is legacy.
+ * @todo Don't use any information from lead.
+ */
+struct rpmlead_s {
+    unsigned char magic[4];
+    unsigned char major;
+    unsigned char minor;
+    short type;
+    short archnum;
+    char name[66];
+    short osnum;
+    short signature_type;       /*!< Signature header type (RPMSIG_HEADERSIG) */
+    char reserved[16];      /*!< Pad to 96 bytes -- 8 byte aligned! */
+};
+
+/** \ingroup lead
  * Write lead to file handle.
  * @param fd		file handle
  * @param h		package header
  * @return		RPMRC_OK on success, RPMRC_FAIL on error
  */
-rpmRC rpmLeadWrite(FD_t fd, Header h);
+rpmRC rpmLeadWriteFromHeader(FD_t fd, Header h);
+
+/** \ingroup lead
+ * Write lead to file handle.
+ * @param fd		file handle
+ * @param l		lead
+ * @return		RPMRC_OK on success, RPMRC_FAIL on error
+ */
+rpmRC rpmLeadWrite(FD_t fd, struct rpmlead_s l);
 
 /** \ingroup lead
  * Read lead from file handle.
@@ -34,6 +60,15 @@ rpmRC rpmLeadWrite(FD_t fd, Header h);
  * @return		RPMRC_OK on success, RPMRC_FAIL/RPMRC_NOTFOUND on error
  */
 rpmRC rpmLeadRead(FD_t fd, char **emsg);
+
+/** \ingroup lead
+ * Read lead from file handle and return it.
+ * @param fd		file handle
+ * @param[out] emsg		failure message on error (malloced)
+ * @param[out] ret		address of lead
+ * @return		RPMRC_OK on success, RPMRC_FAIL/RPMRC_NOTFOUND on error
+ */
+rpmRC rpmLeadReadAndReturn(FD_t fd, char **emsg, struct rpmlead_s * ret);
 
 #ifdef __cplusplus
 }

--- a/rpm2extents.c
+++ b/rpm2extents.c
@@ -120,6 +120,28 @@ exit:
     return rc;
 }
 
+/**
+ * Check if package is in deny list.
+ * @param package_name	package name
+ * @return 		true if package is in deny list
+ */
+static inline int isInDenyList(char * package_name)
+{
+    int is_in_deny_list = 0;
+    if (package_name) {
+	char *e_denylist = getenv("LIBREPO_TRANSCODE_RPMS_DENYLIST");
+	char *denytlist_item = strtok(e_denylist, ",");
+	while (denytlist_item) {
+	    if (strstr(package_name, denytlist_item)) {
+		is_in_deny_list = 1;
+		break;
+	    }
+	    denytlist_item = strtok(NULL, ",");
+	}
+    }
+	return is_in_deny_list;
+}
+
 static rpmRC process_package(FD_t fdi, FD_t validationi)
 {
     uint32_t diglen;
@@ -152,172 +174,208 @@ static rpmRC process_package(FD_t fdi, FD_t validationi)
     uint32_t offset_ix = 0;
     size_t len;
     int next = 0;
+	struct rpmlead_s l;
+    rpmfiles files = NULL;
+    rpmfi fi = NULL;
+    char *msg = NULL;
 
     fdo = fdDup(STDOUT_FILENO);
 
+    rc = rpmLeadReadAndReturn(fdi, &msg, &l);
+    if (rc != RPMRC_OK)
+	goto exit;
+
+    /* Skip conversion if package is in deny list */
+    if (isInDenyList(l.name)) {
+	if (rpmLeadWrite(fdo, l)) {
+		fprintf(stderr, _("Unable to write package lead: %s\n"),
+		Fstrerror(fdo));
+	    rc = RPMRC_FAIL;
+	    goto exit;
+	}
+
+	ssize_t fdilength = ufdCopy(fdi, fdo);
+	if (fdilength == -1) {
+	    fprintf(stderr, _("process_package cat failed\n"));
+	    rc = RPMRC_FAIL;
+	    goto exit;
+	}
+
+	goto exit;
+    } else {
     if (rpmReadPackageRaw(fdi, &sigh, &h)) {
 	fprintf(stderr, _("Error reading package\n"));
 	exit(EXIT_FAILURE);
     }
 
-    if (rpmLeadWrite(fdo, h))
+    if (rpmLeadWriteFromHeader(fdo, h))
     {
 	fprintf(stderr, _("Unable to write package lead: %s\n"),
 		Fstrerror(fdo));
 	exit(EXIT_FAILURE);
     }
 
-    if (rpmWriteSignature(fdo, sigh)) {
-	fprintf(stderr, _("Unable to write signature: %s\n"), Fstrerror(fdo));
-	exit(EXIT_FAILURE);
-    }
-
-    if (headerWrite(fdo, h, HEADER_MAGIC_YES)) {
-	fprintf(stderr, _("Unable to write headers: %s\n"), Fstrerror(fdo));
-	exit(EXIT_FAILURE);
-    }
-
-    /* Retrieve payload size and compression type. */
-    {
-	const char *compr = headerGetString(h, RPMTAG_PAYLOADCOMPRESSOR);
-	rpmio_flags = rstrscat(NULL, "r.", compr ? compr : "gzip", NULL);
-    }
-
-    gzdi = Fdopen(fdi, rpmio_flags);	/* XXX gzdi == fdi */
-    free(rpmio_flags);
-
-    if (gzdi == NULL) {
-	fprintf(stderr, _("cannot re-open payload: %s\n"), Fstrerror(gzdi));
-	exit(EXIT_FAILURE);
-    }
-
-    rpmfiles files = rpmfilesNew(NULL, h, 0, RPMFI_KEEPHEADER);
-    rpmfi fi = rpmfiNewArchiveReader(gzdi, files,
-				     RPMFI_ITER_READ_ARCHIVE_CONTENT_FIRST);
-
-    /* this is encoded in the file format, so needs to be fixed size (for
-     * now?)
-     */
-    diglen = (uint32_t)rpmDigestLength(rpmfiDigestAlgo(fi));
-    digestSet ds = digestSetCreate(rpmfiFC(fi), digestSetHash, digestSetCmp,
-				   NULL);
-    struct digestoffset offsets[rpmfiFC(fi)];
-    pos = RPMLEAD_SIZE + headerSizeof(sigh, HEADER_MAGIC_YES);
-
-    /* main headers are aligned to 8 byte boundry */
-    pos += pad_to(pos, 8);
-    pos += headerSizeof(h, HEADER_MAGIC_YES);
-
-    zeros = xcalloc(fundamental_block_size, 1);
-
-    while (next >= 0) {
-	next = rpmfiNext(fi);
-	if (next == RPMERR_ITER_END) {
-	    rc = RPMRC_OK;
-	    break;
+	if (rpmWriteSignature(fdo, sigh)) {
+	    fprintf(stderr, _("Unable to write signature: %s\n"),
+		    Fstrerror(fdo));
+	    exit(EXIT_FAILURE);
 	}
-	mode = rpmfiFMode(fi);
-	if (!S_ISREG(mode) || !rpmfiArchiveHasContent(fi)) {
-	    /* not a regular file, or the archive doesn't contain any content
-	     * for this entry.
-	    */
-	    continue;
+
+	if (headerWrite(fdo, h, HEADER_MAGIC_YES)) {
+	    fprintf(stderr, _("Unable to write headers: %s\n"),
+		    Fstrerror(fdo));
+	    exit(EXIT_FAILURE);
 	}
-	digest = rpmfiFDigest(fi, NULL, NULL);
-	if (digestSetGetEntry(ds, digest, NULL)) {
-	    /* This specific digest has already been included, so skip it. */
-	    continue;
+
+	/* Retrieve payload size and compression type. */
+	{
+	    const char *compr =
+		headerGetString(h, RPMTAG_PAYLOADCOMPRESSOR);
+	    rpmio_flags =
+		rstrscat(NULL, "r.", compr ? compr : "gzip", NULL);
 	}
-	pad = pad_to(pos, fundamental_block_size);
+
+	gzdi = Fdopen(fdi, rpmio_flags);	/* XXX gzdi == fdi */
+	free(rpmio_flags);
+
+	if (gzdi == NULL) {
+	    fprintf(stderr, _("cannot re-open payload: %s\n"),
+		    Fstrerror(gzdi));
+	    exit(EXIT_FAILURE);
+	}
+
+	files = rpmfilesNew(NULL, h, 0, RPMFI_KEEPHEADER);
+	fi = rpmfiNewArchiveReader(gzdi, files,
+				   RPMFI_ITER_READ_ARCHIVE_CONTENT_FIRST);
+
+	/* this is encoded in the file format, so needs to be fixed size (for
+	 * now?)
+	 */
+	diglen = (uint32_t) rpmDigestLength(rpmfiDigestAlgo(fi));
+	digestSet ds =
+	    digestSetCreate(rpmfiFC(fi), digestSetHash, digestSetCmp,
+			    NULL);
+	struct digestoffset offsets[rpmfiFC(fi)];
+	pos = RPMLEAD_SIZE + headerSizeof(sigh, HEADER_MAGIC_YES);
+
+	/* main headers are aligned to 8 byte boundry */
+	pos += pad_to(pos, 8);
+	pos += headerSizeof(h, HEADER_MAGIC_YES);
+
+	zeros = xcalloc(fundamental_block_size, 1);
+
+	while (next >= 0) {
+	    next = rpmfiNext(fi);
+	    if (next == RPMERR_ITER_END) {
+		rc = RPMRC_OK;
+		break;
+	    }
+	    mode = rpmfiFMode(fi);
+	    if (!S_ISREG(mode) || !rpmfiArchiveHasContent(fi)) {
+		/* not a regular file, or the archive doesn't contain any content
+		 * for this entry.
+		 */
+		continue;
+	    }
+	    digest = rpmfiFDigest(fi, NULL, NULL);
+	    if (digestSetGetEntry(ds, digest, NULL)) {
+		/* This specific digest has already been included, so skip it. */
+		continue;
+	    }
+	    pad = pad_to(pos, fundamental_block_size);
+	    if (Fwrite(zeros, sizeof(char), pad, fdo) != pad) {
+		fprintf(stderr, _("Unable to write padding\n"));
+		rc = RPMRC_FAIL;
+		goto exit;
+	    }
+	    /* round up to next fundamental_block_size */
+	    pos += pad;
+	    digestSetAddEntry(ds, digest);
+	    offsets[offset_ix].digest = digest;
+	    offsets[offset_ix].pos = pos;
+	    offset_ix++;
+	    size = rpmfiFSize(fi);
+	    rc = rpmfiArchiveReadToFile(fi, fdo, 0);
+	    if (rc != RPMRC_OK) {
+		fprintf(stderr,
+			_("rpmfiArchiveReadToFile failed with %d\n"), rc);
+		goto exit;
+	    }
+	    pos += size;
+	}
+	Fclose(gzdi);		/* XXX gzdi == fdi */
+
+	qsort(offsets, (size_t) offset_ix, sizeof(struct digestoffset),
+	      digestoffsetCmp);
+
+	len = sizeof(offset_ix);
+	if (Fwrite(&offset_ix, len, 1, fdo) != len) {
+	    fprintf(stderr, _("Unable to write length of table\n"));
+	    rc = RPMRC_FAIL;
+	    goto exit;
+	}
+	len = sizeof(diglen);
+	if (Fwrite(&diglen, len, 1, fdo) != len) {
+	    fprintf(stderr, _("Unable to write length of digest\n"));
+	    rc = RPMRC_FAIL;
+	    goto exit;
+	}
+	len = sizeof(rpm_loff_t);
+	for (int x = 0; x < offset_ix; x++) {
+	    if (Fwrite(offsets[x].digest, diglen, 1, fdo) != diglen) {
+		fprintf(stderr, _("Unable to write digest\n"));
+		rc = RPMRC_FAIL;
+		goto exit;
+	    }
+	    if (Fwrite(&offsets[x].pos, len, 1, fdo) != len) {
+		fprintf(stderr, _("Unable to write offset\n"));
+		rc = RPMRC_FAIL;
+		goto exit;
+	    }
+	}
+	validation_pos = (pos + sizeof(offset_ix) + sizeof(diglen) +
+			  offset_ix * (diglen + sizeof(rpm_loff_t))
+	    );
+
+	ssize_t validation_len = ufdCopy(validationi, fdo);
+	if (validation_len == -1) {
+	    fprintf(stderr, _("digest table ufdCopy failed\n"));
+	    rc = RPMRC_FAIL;
+	    goto exit;
+	}
+	/* add more padding so the last file can be cloned. It doesn't matter that
+	 * the table and validation etc are in this space. In fact, it's pretty
+	 * efficient if it is.
+	 */
+
+	pad =
+	    pad_to((validation_pos + validation_len +
+		    2 * sizeof(rpm_loff_t) + sizeof(uint64_t)),
+		   fundamental_block_size);
 	if (Fwrite(zeros, sizeof(char), pad, fdo) != pad) {
-	    fprintf(stderr, _("Unable to write padding\n"));
+	    fprintf(stderr, _("Unable to write final padding\n"));
 	    rc = RPMRC_FAIL;
 	    goto exit;
 	}
-	/* round up to next fundamental_block_size */
-	pos += pad;
-	digestSetAddEntry(ds, digest);
-	offsets[offset_ix].digest = digest;
-	offsets[offset_ix].pos = pos;
-	offset_ix++;
-	size = rpmfiFSize(fi);
-	rc = rpmfiArchiveReadToFile(fi, fdo, 0);
-	if (rc != RPMRC_OK) {
-	    fprintf(stderr, _("rpmfiArchiveReadToFile failed with %d\n"), rc);
-	    goto exit;
-	}
-	pos += size;
-    }
-    Fclose(gzdi);	/* XXX gzdi == fdi */
-
-    qsort(offsets, (size_t)offset_ix, sizeof(struct digestoffset),
-	  digestoffsetCmp);
-
-    len = sizeof(offset_ix);
-    if (Fwrite(&offset_ix, len, 1, fdo) != len) {
-	fprintf(stderr, _("Unable to write length of table\n"));
-	rc = RPMRC_FAIL;
-	goto exit;
-    }
-    len = sizeof(diglen);
-    if (Fwrite(&diglen, len, 1, fdo) != len) {
-	fprintf(stderr, _("Unable to write length of digest\n"));
-	rc = RPMRC_FAIL;
-	goto exit;
-    }
-    len = sizeof(rpm_loff_t);
-    for (int x = 0; x < offset_ix; x++) {
-	if (Fwrite(offsets[x].digest, diglen, 1, fdo) != diglen) {
-	    fprintf(stderr, _("Unable to write digest\n"));
+	zeros = _free(zeros);
+	if (Fwrite(&pos, len, 1, fdo) != len) {
+	    fprintf(stderr, _("Unable to write offset of digest table\n"));
 	    rc = RPMRC_FAIL;
 	    goto exit;
 	}
-	if (Fwrite(&offsets[x].pos, len, 1, fdo) != len) {
-	    fprintf(stderr, _("Unable to write offset\n"));
+	if (Fwrite(&validation_pos, len, 1, fdo) != len) {
+	    fprintf(stderr,
+		    _("Unable to write offset of validation table\n"));
 	    rc = RPMRC_FAIL;
 	    goto exit;
 	}
-    }
-    validation_pos = (
-	pos + sizeof(offset_ix) + sizeof(diglen) +
-	offset_ix * (diglen + sizeof(rpm_loff_t))
-    );
-
-    ssize_t validation_len = ufdCopy(validationi, fdo);
-    if (validation_len == -1) {
-	fprintf(stderr, _("digest table ufdCopy failed\n"));
-	rc = RPMRC_FAIL;
-	goto exit;
-    }
-    /* add more padding so the last file can be cloned. It doesn't matter that
-     * the table and validation etc are in this space. In fact, it's pretty
-     * efficient if it is.
-    */
-
-    pad = pad_to((validation_pos + validation_len + 2 * sizeof(rpm_loff_t) +
-		 sizeof(uint64_t)), fundamental_block_size);
-    if (Fwrite(zeros, sizeof(char), pad, fdo) != pad) {
-	fprintf(stderr, _("Unable to write final padding\n"));
-	rc = RPMRC_FAIL;
-	goto exit;
-    }
-    zeros = _free(zeros);
-    if (Fwrite(&pos, len, 1, fdo) != len) {
-	fprintf(stderr, _("Unable to write offset of digest table\n"));
-	rc = RPMRC_FAIL;
-	goto exit;
-    }
-    if (Fwrite(&validation_pos, len, 1, fdo) != len) {
-	fprintf(stderr, _("Unable to write offset of validation table\n"));
-	rc = RPMRC_FAIL;
-	goto exit;
-    }
-    uint64_t magic = MAGIC;
-    len = sizeof(magic);
-    if (Fwrite(&magic, len, 1, fdo) != len) {
-	fprintf(stderr, _("Unable to write magic\n"));
-	rc = RPMRC_FAIL;
-	goto exit;
+	uint64_t magic = MAGIC;
+	len = sizeof(magic);
+	if (Fwrite(&magic, len, 1, fdo) != len) {
+	    fprintf(stderr, _("Unable to write magic\n"));
+	    rc = RPMRC_FAIL;
+	    goto exit;
+	}
     }
 
 exit:

--- a/sign/rpmgensig.c
+++ b/sign/rpmgensig.c
@@ -672,7 +672,7 @@ static int rpmSign(const char *rpm, int deleting, int flags)
 	}
 
 	/* Write the lead/signature of the output rpm */
-	rc = rpmLeadWrite(ofd, h);
+	rc = rpmLeadWriteFromHeader(ofd, h);
 	if (rc != RPMRC_OK) {
 	    rpmlog(RPMLOG_ERR, _("%s: writeLead failed: %s\n"), trpm,
 		Fstrerror(ofd));


### PR DESCRIPTION
A couple of issues were encountered when using RPM CoW for some packages. This change adds a deny list mechanism to disable RPM CoW for specific packages.